### PR TITLE
Prevent contact form submission if email address is not inserted correctly

### DIFF
--- a/src/Components/Menu/ContactUs.jsx
+++ b/src/Components/Menu/ContactUs.jsx
@@ -14,6 +14,12 @@ class ContactUs extends Component {
 
     const { t } = this.props
 
+    const validate = values => {
+      const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+      const invalid = !values.email || !emailRegex.test(values.email) 
+      return invalid
+    }
+
     if (this.props.tReady) {
       return (
         <>
@@ -54,7 +60,8 @@ class ContactUs extends Component {
                           />
                           <Form.Input
                             as='input'
-                            pattern="/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/"
+                            type="email"
+                            validate={validate}
                             required
                             name='email'
                             placeholder={t('ContactUs:email-placeholder')}


### PR DESCRIPTION
Quick fix to prevent contact form submission when the users insert random strings instead of email addresses in the email field.

PT : https://www.pivotaltracker.com/story/show/174885017

<img width="870" alt="Screenshot 2020-09-19 at 12 31 28" src="https://user-images.githubusercontent.com/36330727/93665091-1abd8600-fa74-11ea-8b42-7fe23e6b04d6.png">

